### PR TITLE
Add install dependencies to lint job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Install dependencies
+        run: npm install
+
       - name: Run ESLint
         run: npx eslint . --ext .js,.jsx,.ts,.tsx
   

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "test": "echo No tests yet!"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
The purpose of this pull request is to fix the linting bug.  I believe this was caused by simply not instaling dependencies before running eslint.  This caused the react app config to not be installed and therefore not be found.  Resolves #41 .