### PR TITLE
#52 support new transaction query params

### DIFF
--- a/src/content/applications/Transactions/Transactions.tsx
+++ b/src/content/applications/Transactions/Transactions.tsx
@@ -8,70 +8,76 @@ import { getCookie } from 'src/utilities/utils';
 const Transactions = () => {
 
     // list of transactions fetched from Plaid API
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [categoriesState, setCategoriesState] = useState<string[]>([]);
-  let accounts = new Map();
-  let categoriesSet = new Set<string>();
-  categoriesSet.add('All');
+    const [transactions, setTransactions] = useState<Transaction[]>([]);
+    const [categoriesState, setCategoriesState] = useState<string[]>([]);
+    let accounts = new Map();
+    let categoriesSet = new Set<string>();
+    categoriesSet.add('All');
 
-  const fetchData = async () => {
-    
-    // retrieves accounts from the user
-    await axios.get('http://localhost:8000/api/accounts', {
-      headers: {
-        authorization: 'Bearer ' + getCookie("auth_token"),
-      }
-    }).then((response) => {
-      
-      // stores the accounts in a map that will be used to link each transaction to respective account
-      for(var account of response.data){
-        accounts.set(account.id, account.name);
-      }
-    })
-    
-    // retrieves the transactions from the user
-    axios.get('http://localhost:8000/api/transactions', {
-        headers: {
-          authorization: 'Bearer ' + getCookie("auth_token"),
-        }
-      }).then((response) => {
+    const fetchData = async () => {
 
-        // populates the accounts array with data from response
-        let tempTransactions: Transaction[] = [];
-        
-        response.data.forEach((transaction, key) => {
-
-          // pushes all fetched transactions to temp transactions array
-          tempTransactions.push(
-            { 
-              transactionID: key.toString(),
-              accountID: transaction.accountID,
-              amount: transaction.amount,
-              category: transaction.categories[0],
-              date: transaction.date, 
-              details: transaction.details,
-              name: transaction.name,
-              sourceName: accounts.get(transaction.accountID),
-              sourceAccount: '*****' + transaction.accountID.substring(transaction.accountID.length - 8),
-              currency: 'USD',
+        // retrieves accounts from the user
+        await axios.get('http://localhost:8000/api/accounts', {
+            headers: {
+                authorization: 'Bearer ' + getCookie("auth_token"),
             }
-          );
+        }).then((response) => {
 
-          categoriesSet.add(transaction.categories[0]);
-          setCategoriesState(Array.from(categoriesSet));
-        });
-        setTransactions(tempTransactions);
-      })
-  }
+            // stores the accounts in a map that will be used to link each transaction to respective account
+            for(var account of response.data){
+                accounts.set(account.id, account.name);
+            }
+        })
 
-  // eslint-disable-next-line
-  useEffect(() => { fetchData(); }, []);
-  
-  return (
-    <Card>
-      <TransactionsTable transactions={transactions} categories={categoriesState}/>
-    </Card>
-  );
+        let plaidTransactions: Transaction[] = [];
+        let totalTransactions = 1;
+        while (plaidTransactions.length < totalTransactions) {
+            // retrieves the transactions from the user (PAGINATED)
+            let response = await axios.get('http://localhost:8000/api/transactions', {
+                headers: {
+                    authorization: 'Bearer ' + getCookie("auth_token"),
+                },
+                params: {
+                    offset: plaidTransactions.length
+                }
+            });
+
+            totalTransactions = response.data.total_transactions;
+
+            // populates the transactions array with data from response
+            response.data.transactions.forEach((transaction, key) => {
+
+                // pushes all fetched transactions to temp transactions array
+                plaidTransactions.push(
+                    {
+                        transactionID: key.toString(),
+                        accountID: transaction.accountID,
+                        amount: transaction.amount,
+                        category: transaction.categories[0],
+                        date: transaction.date,
+                        details: transaction.details,
+                        name: transaction.name,
+                        sourceName: accounts.get(transaction.accountID),
+                        sourceAccount: '*****' + transaction.accountID.substring(transaction.accountID.length - 8),
+                        currency: 'USD',
+                    }
+                );
+
+                categoriesSet.add(transaction.categories[0]);
+                setCategoriesState(Array.from(categoriesSet));
+            });
+            setTransactions(plaidTransactions);
+        }
+    }
+
+    // eslint-disable-next-line
+    useEffect(() => { fetchData(); }, []);
+
+    return (
+        <Card>
+            <TransactionsTable transactions={transactions} categories={categoriesState}/>
+        </Card>
+    );
 }
 
 export default Transactions;

--- a/src/utils/cashflow.tsx
+++ b/src/utils/cashflow.tsx
@@ -68,12 +68,18 @@ async function retrieveData(start, end) {
     await axios.get('/api/transactions', {
         headers: {
             authorization: 'Bearer ' + authToken,
+        },
+        params: {
+            start_date: formatDate(start),
+            end_date: formatDate(end)
         }
     }).then(res => {
-        transactions = res.data;
+        transactions = res.data.transactions;
     }).catch(error => {
         return error;
     });
+
+    console.log(transactions);
 
     // Generate date range
     let currentDate = start;


### PR DESCRIPTION
The purpose of this pull request is to take advantage of the new server functionality to speed up transaction loading on the dashboard component and transactions page.  More specifically, the dashboard component takes advantage of the start and end date query options, and the transactions page fetches 100 transactions at a time using the offset query option (the page kinda freezes between 100 transaction requests,  which is something to be possibly looked at later).

Resolves #52 